### PR TITLE
fix: order results and refactor for speed

### DIFF
--- a/dag_run_overview/templates/main.html
+++ b/dag_run_overview/templates/main.html
@@ -93,7 +93,7 @@
                     </span>
                   </td>
                   <td>
-                    {% if dag.state == 'running' or dag.state == 'failed' %}
+                    {% if dag.tasks %}
                       {% for task in dag.tasks %}
                         {{ task.task_id }}{% if not loop.last %}, {% endif %}
                       {% endfor %}

--- a/dag_run_overview/views.py
+++ b/dag_run_overview/views.py
@@ -12,11 +12,22 @@ class DROView(BaseView):
     @expose("/")
     @provide_session
     def list(self, session=None):
+        state_filter = request.args.get('state')
+
         dags = []
-        for dag in session.query(DagModel).filter(DagModel.is_paused == False):
-            last_run = dag.get_last_dagrun(include_externally_triggered=True)
+
+        for dag in (
+            session.query(DagModel)
+            .filter(DagModel.is_paused == False)
+            .order_by(DagModel.dag_id)
+        ):
+            last_run = dag.get_last_dagrun(
+                session=session, include_externally_triggered=True
+            )
             if last_run is not None:
                 current_state = last_run.get_state()
+                if state_filter and current_state != state_filter:
+                    continue
                 dags.append(
                     {
                         'dag_id': dag.dag_id,
@@ -27,18 +38,17 @@ class DROView(BaseView):
                         'tasks': sorted(
                             [
                                 task
-                                for task in last_run.get_task_instances()
-                                if task.current_state() == current_state
-                                and task.start_date is not None
+                                for task in last_run.get_task_instances(
+                                    session=session, state=current_state
+                                )
+                                if task.start_date is not None
                             ],
                             key=lambda x: x.start_date,
-                        ),
+                        )
+                        if current_state in [State.RUNNING, State.FAILED]
+                        else [],
                     }
                 )
-
-        state_filter = request.args.get('state')
-        if state_filter:
-            dags = filter(lambda x: x['state'] == state_filter, dags)
 
         return self.render_template(
             "main.html", dags=dags, State=State, filter=state_filter


### PR DESCRIPTION
1. Order results by name
2. Filter out unwanted states earlier to stop us having to fetch tasks for dags we're not interested in
3. Use sqlalchemy/airflow's built in filters where possible