### PR TITLE
fix: exception when last DAG has not started

### DIFF
--- a/dag_run_overview/templates/main.html
+++ b/dag_run_overview/templates/main.html
@@ -71,7 +71,11 @@
                     </span>
                   </td>
                   <td>
-                    {{ dag.last_dag_run.start_date.strftime('%c') }}
+                    {% if dag.last_dag_run.start_date %}
+                      {{ dag.last_dag_run.start_date.strftime('%c') }}
+                    {% else %}
+                      N/A
+                    {% endif %}
                   </td>
                   <td>
                     {% if dag.last_dag_run.end_date %}


### PR DESCRIPTION
This can happen if it's queued, and waiting for a previous DAG run to finish. This can happen with the smart_sensor_group_shard DAGs (although not sure if that is itself a bug at this point...)