### PR TITLE
fix: do not use hawk auth for js endpoints

### DIFF
--- a/dag_run_overview/static/dag-grid.js
+++ b/dag_run_overview/static/dag-grid.js
@@ -97,7 +97,7 @@ function dateFilterComparator(filterDate, cellDate) {
 
 function clearDags(dag_ids, callback) {
   var xhr = new XMLHttpRequest();
-  xhr.open('POST', "/api/experimental/dro/clear-dags", true);
+  xhr.open('POST', "/droview/api/clear-dags", true);
   xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
   xhr.onreadystatechange = function() {
     if (this.readyState === XMLHttpRequest.DONE) {
@@ -109,7 +109,7 @@ function clearDags(dag_ids, callback) {
 
 function clearHighPriorityDags( callback) {
   var xhr = new XMLHttpRequest();
-  xhr.open('POST', "/api/experimental/dro/clear-failed-dags?tag=High%20Priority", true);
+  xhr.open('POST', "/droview/api/clear-failed-dags?tag=High%20Priority", true);
   xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
   xhr.onreadystatechange = function() {
     if (this.readyState === XMLHttpRequest.DONE) {
@@ -121,7 +121,7 @@ function clearHighPriorityDags( callback) {
 
 function refreshGrid(gridOptions, callback) {
   var xhr = new XMLHttpRequest();
-  xhr.open('GET', "/api/experimental/dro/latest-dag-runs", true);
+  xhr.open('GET', "/droview/api/latest-dag-runs", true);
   xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
   xhr.onreadystatechange = function() {
     if (this.readyState === XMLHttpRequest.DONE) {

--- a/dag_run_overview/views.py
+++ b/dag_run_overview/views.py
@@ -40,68 +40,62 @@ class DROView(BaseView):
             priority_filter=priority,
         )
 
+    @expose("/api/latest-dag-runs", ["GET"])
+    @provide_session
+    def list_latest_dag_runs(self, session=None):
+        """
+        Returns the last run information for all enabled DAGs. Optionally filtered
+        by state and tag.
+        """
+        state_filter = request.args.get('state')
+        tag_filter = request.args.get('tag')
+        return jsonify(get_latest_dag_runs(session, state_filter, tag_filter))
 
-@api_experimental.route('/dro/latest-dag-runs', methods=['GET'])
-@requires_authentication
-@provide_session
-def list_latest_dag_runs(session):
-    """
-    Returns the last run information for all enabled DAGs. Optionally filtered
-    by state and tag.
-    """
-    state_filter = request.args.get('state')
-    tag_filter = request.args.get('tag')
-    return jsonify(get_latest_dag_runs(session, state_filter, tag_filter))
+    @expose('/api/clear-failed-dags', ['POST'])
+    @provide_session
+    def clear_failed_dag_runs(self, session=None):
+        """
+        Clear all tasks for all failed DAGs (that are enabled). Optionally filtering by tag.
+        """
+        tag_filter = request.args.get('tag')
+        cleared_count = 0
+        for dag in get_enabled_dags(session, request.args.get('tag')):
+            last_run = dag.get_last_dagrun(
+                session=session, include_externally_triggered=True
+            )
+            if last_run is None or get_dag_state(last_run) != State.FAILED:
+                continue
 
+            if tag_filter and tag_filter not in [x.name for x in dag.tags]:
+                continue
 
-@api_experimental.route('/dro/clear-failed-dags', methods=['POST'])
-@requires_authentication
-@provide_session
-def clear_failed_dag_runs(session):
-    """
-    Clear all tasks for all failed DAGs (that are enabled). Optionally filtering by tag.
-    """
-    tag_filter = request.args.get('tag')
-    cleared_count = 0
-    for dag in get_enabled_dags(session, request.args.get('tag')):
-        last_run = dag.get_last_dagrun(
-            session=session, include_externally_triggered=True
+            clear_task_instances(last_run.get_task_instances(), session)
+            cleared_count += 1
+        return jsonify(status=f"Cleared tasks for {cleared_count} failed DAGs")
+
+    @expose('/api/clear-dags', ['POST'])
+    @provide_session
+    def clear_dag_runs(self, session=None):
+        """
+        Given a json object containing a `dag_igs` list, clear all tasks for
+        the specified ids. If the DAG ID does not exist or the DAG is disabled
+        it will be skipped.
+        """
+        if "dag_ids" not in request.json:
+            return abort(
+                make_response(jsonify(status="Please provide a list of dag_ids"), 400)
+            )
+        cleared_count = 0
+        dags = [x for x in get_enabled_dags(session) if x.dag_id in request.json["dag_ids"]]
+        for dag in dags:
+            last_run = dag.get_last_dagrun(
+                session=session, include_externally_triggered=True
+            )
+            if last_run is None:
+                continue
+
+            clear_task_instances(last_run.get_task_instances(), session)
+            cleared_count += 1
+        return jsonify(
+            status=f"Cleared tasks for {cleared_count} DAG{'s' if cleared_count != 1 else ''}"
         )
-        if last_run is None or get_dag_state(last_run) != State.FAILED:
-            continue
-
-        if tag_filter and tag_filter not in [x.name for x in dag.tags]:
-            continue
-
-        clear_task_instances(last_run.get_task_instances(), session)
-        cleared_count += 1
-    return jsonify(status=f"Cleared tasks for {cleared_count} failed DAGs")
-
-
-@api_experimental.route('/dro/clear-dags', methods=['POST'])
-@requires_authentication
-@provide_session
-def clear_dag_runs(session):
-    """
-    Given a json object containing a `dag_igs` list, clear all tasks for
-    the specified ids. If the DAG ID does not exist or the DAG is disabled
-    it will be skipped.
-    """
-    if "dag_ids" not in request.json:
-        return abort(
-            make_response(jsonify(status="Please provide a list of dag_ids"), 400)
-        )
-    cleared_count = 0
-    dags = [x for x in get_enabled_dags(session) if x.dag_id in request.json["dag_ids"]]
-    for dag in dags:
-        last_run = dag.get_last_dagrun(
-            session=session, include_externally_triggered=True
-        )
-        if last_run is None:
-            continue
-
-        clear_task_instances(last_run.get_task_instances(), session)
-        cleared_count += 1
-    return jsonify(
-        status=f"Cleared tasks for {cleared_count} DAG{'s' if cleared_count != 1 else ''}"
-    )


### PR DESCRIPTION
We don't want the management endpoints behind hawk auth (currently) as auth is handled by flask on the frontend.